### PR TITLE
Update to handle name change from 3PC -> PArSEC

### DIFF
--- a/common/normalizedtestrun.go
+++ b/common/normalizedtestrun.go
@@ -165,7 +165,7 @@ func (tr *TestRun) NormalizedConfigWithAgentData(
 			cpu,
 			SystemRoleAtomizerCliWatchtower,
 			SystemRoleTwoPhaseGen,
-			SystemRolePhaseTwoGen,
+			SystemRoleParsecGen,
 		),
 	)
 	trc.SentinelCPU = int(
@@ -198,7 +198,7 @@ func (tr *TestRun) NormalizedConfigWithAgentData(
 			ram,
 			SystemRoleAtomizerCliWatchtower,
 			SystemRoleTwoPhaseGen,
-			SystemRolePhaseTwoGen,
+			SystemRoleParsecGen,
 		) / 1024,
 	)
 	trc.SentinelRAM = int(
@@ -236,7 +236,7 @@ func (tr *TestRun) NormalizedConfigWithAgentData(
 		count,
 		SystemRoleAtomizerCliWatchtower,
 		SystemRoleTwoPhaseGen,
-		SystemRolePhaseTwoGen,
+		SystemRoleParsecGen,
 	)
 	trc.SentinelCount = getIntValueForAnyKey(
 		count,

--- a/common/system.go
+++ b/common/system.go
@@ -20,7 +20,7 @@ const SystemRoleTwoPhaseGen SystemRole = "twophase-gen"
 const SystemRoleAgent SystemRole = "agent"
 const SystemRoleRuntimeLockingShard SystemRole = "runtime_locking_shard"
 const SystemRoleTicketMachine SystemRole = "ticket_machine"
-const SystemRolePhaseTwoGen SystemRole = "phasetwo_bench"
+const SystemRoleParsecGen SystemRole = "parsec_bench"
 const SystemRoleLoadGen SystemRole = "loadgen"
 
 type SystemArchitectureRole struct {
@@ -223,8 +223,8 @@ var AvailableArchitectures = []SystemArchitecture{
 		},
 	},
 	{
-		ID:   "phase-two",
-		Name: "Phase Two Programmability",
+		ID:   "parsec",
+		Name: "PArSEC",
 		Roles: []SystemArchitectureRole{
 			{
 				Role:       SystemRoleAgent,
@@ -242,7 +242,7 @@ var AvailableArchitectures = []SystemArchitecture{
 				ShortTitle: "Ticketer",
 			},
 			{
-				Role:       SystemRolePhaseTwoGen,
+				Role:       SystemRoleParsecGen,
 				Title:      "Generator",
 				ShortTitle: "Gen",
 			},
@@ -261,7 +261,7 @@ var AvailableArchitectures = []SystemArchitecture{
 			RaftMaxBatch:              100000,
 			SnapshotDistance:          0,
 			ShardReplicationFactor:    3,
-			Architecture:              "phase-two",
+			Architecture:              "parsec",
 			SampleCount:               315,
 			LoadGenOutputCount:        2,
 			LoadGenInputCount:         2,

--- a/coordinator/sources/sources.go
+++ b/coordinator/sources/sources.go
@@ -249,7 +249,7 @@ func (s *SourcesManager) Compile(
 	proxy_path := filepath.Join(
 		sourcesDir(),
 		"src",
-		"3pc",
+		"parsec",
 		"agent",
 		"runners",
 		"evm",
@@ -257,14 +257,14 @@ func (s *SourcesManager) Compile(
 	)
 	if _, err := os.Stat(proxy_path); !os.IsNotExist(err) {
 		logging.Infof(
-			"[Compile %s-%t]: Copying 3PC/EVM RPC proxy",
+			"[Compile %s-%t]: Copying parsec/EVM RPC proxy",
 			hash,
 			profilingOrDebugging,
 		)
 		dest_proxy_path := filepath.Join(
 			binariesPath,
 			"src",
-			"3pc",
+			"parsec",
 			"agent",
 			"runners",
 			"evm",

--- a/coordinator/testruns/architecture_phase_two.go
+++ b/coordinator/testruns/architecture_phase_two.go
@@ -8,20 +8,20 @@ import (
 	"github.com/mit-dci/opencbdc-tctl/common"
 )
 
-func (t *TestRunManager) IsPhaseTwo(architectureID string) bool {
-	return strings.HasPrefix(architectureID, "phase-two")
+func (t *TestRunManager) IsParsec(architectureID string) bool {
+	return strings.HasPrefix(architectureID, "parsec")
 }
 
-// RunBinariesPhaseTwo will orchestrate the running of all roles for a full
-// cycle test with the phase two architecture
-func (t *TestRunManager) RunBinariesPhaseTwo(
+// RunBinariesParsec will orchestrate the running of all roles for a full
+// cycle test with the PArSEC architecture
+func (t *TestRunManager) RunBinariesParsec(
 	tr *common.TestRun,
 	envs map[int32][]byte,
 	cmd chan *common.ExecutedCommand,
 	failures chan *common.ExecutedCommand,
 ) error {
 	// Build the sequence of commands to start
-	startSequence := t.CreateStartSequencePhaseTwo(tr)
+	startSequence := t.CreateStartSequenceParsec(tr)
 
 	// Execute the sequence of commands to start
 	allCmds, terminated, err := t.executeStartSequence(
@@ -76,7 +76,7 @@ func (t *TestRunManager) RunBinariesPhaseTwo(
 	case <-time.After(timeout):
 	}
 
-	err = t.CleanupCommandsPhaseTwo(tr, allCmds, envs)
+	err = t.CleanupCommandsParsec(tr, allCmds, envs)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (t *TestRunManager) RunBinariesPhaseTwo(
 	return nil
 }
 
-func (t *TestRunManager) CleanupCommandsPhaseTwo(
+func (t *TestRunManager) CleanupCommandsParsec(
 	tr *common.TestRun,
 	allCmds []runningCommand,
 	envs map[int32][]byte,
@@ -109,7 +109,7 @@ func (t *TestRunManager) CleanupCommandsPhaseTwo(
 	t.WriteLog(tr, "Interrupting all loadgens")
 	err := t.BreakAllCmds(
 		tr,
-		t.FilterCommandsByRole(tr, allCmds, common.SystemRolePhaseTwoGen),
+		t.FilterCommandsByRole(tr, allCmds, common.SystemRoleParsecGen),
 	)
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func (t *TestRunManager) CleanupCommandsPhaseTwo(
 	t.WriteLog(tr, "Terminating all loadgens")
 	err = t.TerminateAllCmds(
 		tr,
-		t.FilterCommandsByRole(tr, allCmds, common.SystemRolePhaseTwoGen),
+		t.FilterCommandsByRole(tr, allCmds, common.SystemRoleParsecGen),
 	)
 	if err != nil {
 		return err
@@ -183,11 +183,11 @@ func (t *TestRunManager) CleanupCommandsPhaseTwo(
 	return nil
 }
 
-// CreateStartSequencePhaseTwo uses the test run configuration to determine in
+// CreateStartSequenceParsec uses the test run configuration to determine in
 // which sequence the agent roles should be started, and returns an array of
 // startSequenceEntry elements that are ordered in the sequence in which they
 // should be started up.
-func (t *TestRunManager) CreateStartSequencePhaseTwo(
+func (t *TestRunManager) CreateStartSequenceParsec(
 	tr *common.TestRun,
 ) []startSequenceEntry {
 	// Determine the start sequence
@@ -236,7 +236,7 @@ func (t *TestRunManager) CreateStartSequencePhaseTwo(
 
 	// Start all load generators
 	startSequence = append(startSequence, startSequenceEntry{
-		roles:       t.GetAllRolesSorted(tr, common.SystemRolePhaseTwoGen),
+		roles:       t.GetAllRolesSorted(tr, common.SystemRoleParsecGen),
 		timeout:     roleStartTimeout,
 		waitForPort: []PortIncrement{}, // Don't wait for anything - loadgens don't accept incoming
 	})

--- a/coordinator/testruns/commands.go
+++ b/coordinator/testruns/commands.go
@@ -33,7 +33,7 @@ var roleBinaries = map[common.SystemRole]string{
 	common.SystemRoleAgent:                 "sources/build/src/parsec/agent/agentd",
 	common.SystemRoleRuntimeLockingShard:   "sources/build/src/parsec/runtime_locking_shard/runtime_locking_shardd",
 	common.SystemRoleTicketMachine:         "sources/build/src/parsec/ticket_machine/ticket_machined",
-	common.SystemRolePhaseTwoGen:           "sources/build/tools/bench/parsec/evm/evm_bench",
+	common.SystemRoleParsecGen:           "sources/build/tools/bench/parsec/evm/evm_bench",
 }
 
 // roleParameters is a map from the system role to the parameters we have to
@@ -78,7 +78,7 @@ var roleParameters = map[common.SystemRole][]string{
 		"--loglevel=%LOGLEVEL%",
 		"--component_id=%IDX%",
 	},
-	common.SystemRolePhaseTwoGen: []string{
+	common.SystemRoleParsecGen: []string{
 		"--component_id=%IDX%",
 		"--loadgen_accounts=%ACCOUNTS%",
 		"--loadgen_agent_affinity=%LGAFFINITY%",
@@ -373,8 +373,8 @@ func (t *TestRunManager) RunBinaries(
 		return t.RunBinariesAtomizer(tr, envs, cmd, failures)
 	} else if t.Is2PC(tr.Architecture) {
 		return t.RunBinariesTwoPhase(tr, envs, cmd, failures)
-	} else if t.IsPhaseTwo(tr.Architecture) {
-		return t.RunBinariesPhaseTwo(tr, envs, cmd, failures)
+	} else if t.IsParsec(tr.Architecture) {
+		return t.RunBinariesParsec(tr, envs, cmd, failures)
 	}
 	return fmt.Errorf("unknown architecture: [%s]", tr.Architecture)
 }

--- a/coordinator/testruns/commands.go
+++ b/coordinator/testruns/commands.go
@@ -30,10 +30,10 @@ var roleBinaries = map[common.SystemRole]string{
 	common.SystemRoleSentinelTwoPhase:      "sources/build/src/uhs/twophase/sentinel_2pc/sentineld-2pc",
 	common.SystemRoleAtomizerCliWatchtower: "sources/build/tools/bench/atomizer-cli-watchtower",
 	common.SystemRoleTwoPhaseGen:           "sources/build/tools/bench/twophase-gen",
-	common.SystemRoleAgent:                 "sources/build/src/3pc/agent/agentd",
-	common.SystemRoleRuntimeLockingShard:   "sources/build/src/3pc/runtime_locking_shard/runtime_locking_shardd",
-	common.SystemRoleTicketMachine:         "sources/build/src/3pc/ticket_machine/ticket_machined",
-	common.SystemRolePhaseTwoGen:           "sources/build/tools/bench/3pc/evm/evm_bench",
+	common.SystemRoleAgent:                 "sources/build/src/parsec/agent/agentd",
+	common.SystemRoleRuntimeLockingShard:   "sources/build/src/parsec/runtime_locking_shard/runtime_locking_shardd",
+	common.SystemRoleTicketMachine:         "sources/build/src/parsec/ticket_machine/ticket_machined",
+	common.SystemRolePhaseTwoGen:           "sources/build/tools/bench/parsec/evm/evm_bench",
 }
 
 // roleParameters is a map from the system role to the parameters we have to

--- a/coordinator/testruns/execute.go
+++ b/coordinator/testruns/execute.go
@@ -85,7 +85,7 @@ func (t *TestRunManager) ExecuteTestRun(tr *common.TestRun) {
 		}
 	}
 
-	if !t.IsPhaseTwo(tr.Architecture) {
+	if !t.IsParsec(tr.Architecture) {
 		// Generate the configuration file the system needs based on the
 		// configured
 		// parameters in the UI

--- a/coordinator/testruns/parameters.go
+++ b/coordinator/testruns/parameters.go
@@ -55,7 +55,7 @@ func (t *TestRunManager) SubstituteParameters(
 			fmt.Sprintf("%d", tr.LoadGenAccounts),
 		)
 		p = strings.ReplaceAll(p, "%LOGLEVEL%", t.RoleLogLevel(tr, r))
-		if r.Role == common.SystemRolePhaseTwoGen {
+		if r.Role == common.SystemRoleParsecGen {
 			p = strings.ReplaceAll(p, "%LGAFFINITY%", t.LoadGenAffinity(tr, r))
 		}
 		newParams = append(newParams, p)

--- a/coordinator/testruns/roleconfig.go
+++ b/coordinator/testruns/roleconfig.go
@@ -205,7 +205,7 @@ func (t *TestRunManager) writeTestRunConfigVariables(
 		numRoles := t.countRoles(tr)
 		numClis := 0
 		numClis += numRoles[common.SystemRoleAtomizerCliWatchtower]
-		numClis += numRoles[common.SystemRolePhaseTwoGen]
+		numClis += numRoles[common.SystemRoleParsecGen]
 		numClis += numRoles[common.SystemRoleTwoPhaseGen]
 
 		// Calculate target per role
@@ -355,7 +355,7 @@ func (t *TestRunManager) RoleTelLevel(
 		tellevel = tr.WatchtowerTelemetryLevel
 	case common.SystemRoleCoordinator:
 		tellevel = tr.CoordinatorTelemetryLevel
-	case common.SystemRolePhaseTwoGen:
+	case common.SystemRoleParsecGen:
 		fallthrough
 	case common.SystemRoleTwoPhaseGen:
 		fallthrough

--- a/coordinator/testruns/roles.go
+++ b/coordinator/testruns/roles.go
@@ -40,7 +40,7 @@ func (t *TestRunManager) NormalizeRole(
 		role = common.SystemRoleShard
 	} else if role == common.SystemRoleSentinelTwoPhase {
 		role = common.SystemRoleSentinel
-	} else if role == common.SystemRoleAtomizerCliWatchtower || role == common.SystemRolePhaseTwoGen || role == common.SystemRoleTwoPhaseGen {
+	} else if role == common.SystemRoleAtomizerCliWatchtower || role == common.SystemRoleParsecGen || role == common.SystemRoleTwoPhaseGen {
 		role = common.SystemRoleLoadGen
 	}
 	return role

--- a/coordinator/testruns/transfer.go
+++ b/coordinator/testruns/transfer.go
@@ -61,7 +61,7 @@ var copyFiles = map[common.SystemRole][]string{
 		"tps_target_%IDX%.txt%%OPT",
 		"telemetry.bin%%OPT",
 	},
-	common.SystemRolePhaseTwoGen: {
+	common.SystemRoleParsecGen: {
 		"tx_samples_%IDX%.txt",
 		"telemetry.bin%%OPT",
 	},


### PR DESCRIPTION
This PR updates the codebase to handle the name change of 3PC to PArSEC. There are two commits in this PR currently, the first updates occurrences of 3PC to parsec, and the second updates occurrences of "phase two" 